### PR TITLE
Simplify setup.py and move towards cookie-cutter configuration

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,5 @@
 recursive-include pythreejs/static *.*
 
-include setupbase.py
-
 include LICENSE
 include README.md
 include pytest.ini

--- a/install.json
+++ b/install.json
@@ -1,0 +1,5 @@
+{
+  "packageManager": "python",
+  "packageName": "pythreejs",
+  "uninstallInstructions": "Use your Python package manager (pip, conda, etc.) to uninstall the package pythreejs"
+}

--- a/js/package.json
+++ b/js/package.json
@@ -54,7 +54,7 @@
   },
   "jupyterlab": {
     "extension": "src/jupyterlab-plugin",
-    "outputDir": "../share/jupyter/labextensions/jupyter-threejs",
+    "outputDir": "../pythreejs/labextension",
     "sharedPackages": {
       "@jupyter-widgets/base": {
         "bundled": false,

--- a/js/package.json
+++ b/js/package.json
@@ -34,14 +34,14 @@
     "watch": "webpack -d -w"
   },
   "dependencies": {
-    "@jupyter-widgets/base": "^1.2.5 || ^2.0.0 || ^3.0.0 || ^4.0.0-alpha.2",
+    "@jupyter-widgets/base": "^1.2.5 || ^2.0.0 || ^3.0.0 || ^4.0.0",
     "bluebird": "^3.5.5",
     "jupyter-dataserializers": "^2.2.0",
     "three": "^0.97.0",
     "underscore": "^1.8.3"
   },
   "devDependencies": {
-    "@jupyterlab/builder": "^3.0.0-rc.13",
+    "@jupyterlab/builder": "^3.0.0",
     "@jupyterlab/buildutils": "^2.0.2",
     "eslint": "^6.8.0",
     "fs-extra": "^8.1.0",

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup_args = {
             'sphinx-rtd-theme',
         ]
     },
-    'packages': setuptools.find_packages(),
+    'packages': [name],
     'zip_safe': False,
     'cmdclass': cmdclass,
     'author': 'PyThreejs Development Team',

--- a/setup.py
+++ b/setup.py
@@ -22,10 +22,13 @@ version = get_version(HERE / name / '_version.py')
 cmdclass = create_cmdclass(
     'js',
     data_files_spec=[
+        # Support JupyterLab 3.x prebuilt extension
         ("share/jupyter/labextensions/jupyter-threejs", str(lab_path), "**"),
         ("share/jupyter/labextensions/jupyter-threejs", str(HERE), "install.json"),
         # Support JupyterLab 2.x
-        ('share/jupyter/lab/extensions', HERE/'js'/'lab-dist', 'jupyter-threejs-*.tgz'),
+        ('share/jupyter/lab/extensions', str(HERE/'js'/'lab-dist'), 'jupyter-threejs-*.tgz'),
+        # Support Jupyter Notebook
+        ('etc/jupyter/nbconfig', str(HERE/'jupyter-config'), '**/*.json')
     ],
 )
 cmdclass['js'] = combine_commands(

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
-
-from __future__ import print_function
-import os
-import sys
+from pathlib import Path
 
 from jupyter_packaging import (
     create_cmdclass,
@@ -11,45 +8,29 @@ from jupyter_packaging import (
     combine_commands,
     get_version,
 )
-
-from setuptools import setup
+import setuptools
 
 
 LONG_DESCRIPTION = 'A Python/ThreeJS bridge utilizing the Jupyter widget infrastructure.'
 
-here = os.path.dirname(os.path.abspath(__file__))
+HERE = Path(__file__).parent.resolve()
 name = 'pythreejs'
-version = get_version(os.path.join(here, name, '_version.py'))
+lab_path = (HERE / name / "labextension")
 
+version = get_version(HERE / name / '_version.py')
 
 cmdclass = create_cmdclass(
     'js',
     data_files_spec=[
-        ('share/jupyter/nbextensions/jupyter-threejs',
-         name + '/static',
-         '*.js'),
-        ('share/jupyter/nbextensions/jupyter-threejs',
-         name + '/static',
-         '*.js.map'),
-        ('share/jupyter/lab/extensions',
-         'js/lab-dist',
-         'jupyter-threejs-*.tgz'),
-        ('share/jupyter/labextensions/jupyter-threejs/',
-         'share/jupyter/labextensions/jupyter-threejs/',
-         '*.*'),
-        ('share/jupyter/labextensions/jupyter-threejs/static',
-         'share/jupyter/labextensions/jupyter-threejs/static/',
-         '*.*'),
-        ('etc/jupyter/nbconfig',
-         'jupyter-config',
-         '**/*.json'),
+        ("share/jupyter/labextensions/jupyter-threejs", str(lab_path), "**"),
+        ("share/jupyter/labextensions/jupyter-threejs", str(HERE), "install.json"),
     ],
 )
 cmdclass['js'] = combine_commands(
     install_npm(
-        path=os.path.join(here, 'js'),
-        build_dir=os.path.join(here, name, 'static'),
-        source_dir=os.path.join(here, 'js'),
+        path=HERE/'js',
+        build_dir=HERE/'name'/'static',
+        source_dir=HERE/'js',
         build_cmd='build:all'
     ),
     ensure_targets([
@@ -110,4 +91,6 @@ setup_args = {
     ],
 }
 
-setup(**setup_args)
+
+if __name__ == "__main__":
+    setuptools.setup(**setup_args)

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup_args = {
             'sphinx-rtd-theme',
         ]
     },
-    'packages': [name],  # Manually specify here, update after autogen
+    'packages': setuptools.find_packages(),
     'zip_safe': False,
     'cmdclass': cmdclass,
     'author': 'PyThreejs Development Team',

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,8 @@ cmdclass = create_cmdclass(
     data_files_spec=[
         ("share/jupyter/labextensions/jupyter-threejs", str(lab_path), "**"),
         ("share/jupyter/labextensions/jupyter-threejs", str(HERE), "install.json"),
+        # Support JupyterLab 2.x
+        ('share/jupyter/lab/extensions', HERE/'js'/'lab-dist', 'jupyter-threejs-*.tgz'),
     ],
 )
 cmdclass['js'] = combine_commands(


### PR DESCRIPTION
This PR bumps the dependency versions of the JS package to follow the released versions rather than RCs.
It also further simplifies setup.py to follow the structure of the cookie-cutter used for prebuilt extensions.
